### PR TITLE
Migrate from Laravel Mix to Vite

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,10 +8,10 @@
         "@popperjs/core": "^2.11.6",
         "axios": "^1.1.2",
         "bootstrap": "^5.2.3",
-        "laravel-vite-plugin": "^0.7.2",
+        "laravel-vite-plugin": "^0.6.0",
         "lodash": "^4.17.19",
         "postcss": "^8.1.14",
         "sass": "^1.56.1",
-        "vite": "^4.0.0"
+        "vite": "^3.0.2"
     }
 }

--- a/vite.config.js
+++ b/vite.config.js
@@ -4,10 +4,7 @@ import laravel from 'laravel-vite-plugin';
 export default defineConfig({
     plugins: [
         laravel({
-            input: [
-                'resources/sass/app.scss',
-                'resources/js/app.js',
-            ],
+            input: ['resources/css/app.css', 'resources/js/app.js'],
             refresh: true,
         }),
     ],


### PR DESCRIPTION
This pull request includes changes for migrating from Laravel Mix to Vite outlined in [Migration Guide](https://github.com/laravel/vite-plugin/blob/main/UPGRADE.md#migrating-from-laravel-mix-to-vite) and automated by the [Vite Converter](https://laravelshift.com/convert-laravel-mix-to-vite).

**Before merging**, you need to:

- Checkout the `shift-134230` branch
- Run `composer update`
- Run `npm install`
- Review **all** comments for additional changes 
- Thoroughly test your application ([no tests?](https://laravelshift.com/laravel-test-generator), [no CI?](https://laravelshift.com/ci-generator))

Please send your feedback to shift@laravelshift.com or share the good vibes on [Twitter](https://twitter.com/laravelshift).
